### PR TITLE
stop collapsing hours intervals and union them instead

### DIFF
--- a/js/app/models/hours.js
+++ b/js/app/models/hours.js
@@ -240,16 +240,16 @@ function humanizeInterval(intervals) {
 }
 
 Hours.prototype.humanize = function() {
-  var result = {}, dayNum;
-  for(var idx = 0; idx < 7; idx++) {
-    if(this.hours[idx]) {
-      result[daysInverse[idx]] = this.hours[idx].map(humanizeInterval).join(",");
-    } else {
-      result[daysInverse[idx]] = "";
-    }
-  }
+  var hours = this.hours;
 
-  return result;
+  return dayNames.map(function(dayName, index) {
+    var intervals = hours[index];
+
+    return {
+      day: dayName,
+      hours: intervals ? intervals.map(humanizeInterval).join(', ') : null
+    };
+  });
 };
 
 Hours.prototype.within = function(time) {

--- a/js/app/templates/_open_hours.hbs
+++ b/js/app/templates/_open_hours.hbs
@@ -1,8 +1,10 @@
 <table class="open-hours">
 {{#each openHours}}
-  <tr>
-    <td class="label-hour"><b>{{label}}</b>:</td>
-    <td class="hour">{{interval}}</td>
-  </tr>
+  {{#if hours}}
+    <tr>
+      <td class="label-hour"><b>{{day}}</b>:</td>
+      <td class="hour">{{hours}}</td>
+    </tr>
+  {{/if}}
 {{/each}}
 </table>

--- a/js/app/views/detail_view.js
+++ b/js/app/views/detail_view.js
@@ -16,24 +16,25 @@ var aggregateOpenHours = function(facility) {
     })
   );
 
+  return mergedHours.humanize();
   // giant hack to get humanize() output into template-ready shape
-  var unformatted = mergedHours.humanize(),
-      formatted = [];
+  // var unformatted = mergedHours.humanize(),
+  //     formatted = [];
 
-  function capitalize(string) {
-    return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
-  }
+  // function capitalize(string) {
+  //   return string.charAt(0).toUpperCase() + string.substring(1).toLowerCase();
+  // }
 
-  ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'].forEach(function(day) {
-    if (unformatted[day].length) {
-      formatted.push({
-        label: capitalize(day),
-        interval: unformatted[day]
-      });
-    }
-  });
+  // ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'].forEach(function(day) {
+  //   if (unformatted[day].length) {
+  //     formatted.push({
+  //       label: capitalize(day),
+  //       interval: unformatted[day]
+  //     });
+  //   }
+  // });
 
-  return formatted;
+  // return formatted;
 };
 
 var DetailView = Backbone.View.extend({

--- a/js/app/views/edit_view.js
+++ b/js/app/views/edit_view.js
@@ -5,7 +5,7 @@ var Backbone            = require('backbone'),
     Hours               = require('cloud/models/hours'),
     fetchLocation       = require('cloud/lib/fetch_location'),
     editServiceTemplate = require('templates/_edit_service'),
-    openHoursTemplate   = require('templates/_open_hours'), 
+    openHoursTemplate   = require('templates/_open_hours'),
     facilities          = require('collections/facilities').instance;
 
 function modelSaveFailCallback(args) {
@@ -23,13 +23,13 @@ function modelSaveSuccessCallback(args) {
 }
 
 var days = [
+  {key: "SUN", name: "Sunday"},
   {key: "MON", name: "Monday"},
   {key: "TUE", name: "Tuesday"},
   {key: "WED", name: "Wednesday"},
   {key: "THU", name: "Thursday"},
   {key: "FRI", name: "Friday"},
-  {key: "SAT", name: "Saturday"},
-  {key: "SUN", name: "Sunday"}
+  {key: "SAT", name: "Saturday"}
 ];
 
 function saveFacility(model, services, successCallback, failCallback) {
@@ -93,7 +93,7 @@ var EditView = Backbone.View.extend({
       [ { hours: openHours } ]
     );
 
-    preview = mergedHours.humanizeCondensed();
+    preview = mergedHours.humanize();
     html    = openHoursTemplate({ openHours: preview });
     $hours.find('#preview_hours').html(html);
   },
@@ -290,8 +290,8 @@ var EditView = Backbone.View.extend({
     templateData.services.forEach(function(service) {
       var openHours = Hours.fromData(service.openHours).humanize();
 
-      service.days = days.map(function(day) {
-        return {key: day.key, name: day.name, hours: openHours[day.key]};
+      service.days = days.map(function(day, index) {
+        return {key: day.key, name: day.name, hours: openHours[index].hours};
       });
     });
 

--- a/test/hours_test.js
+++ b/test/hours_test.js
@@ -84,22 +84,22 @@ describe("Hours", function(){
         Mon: "9AM-12PM,2PM-5PM",
         Tue: "9AM-12AM",
         Wed: "9AM-6PM",
-        Thu: "9AM-6PM",
         Fri: "9AM-6PM",
         Sat: "9:00AM-11:00AM,2pm-5:30pm"
       });
     });
 
-    it("should convert back to AM/PM strings", function() {
-      hours.humanize().should.eql({
-        "SUN": "9:00 AM - 6:00 PM",
-        "MON": "9:00 AM - 12:00 PM,2:00 PM - 5:00 PM",
-        "TUE": "9:00 AM - 12:00 AM",
-        "WED": "9:00 AM - 6:00 PM",
-        "THU": "9:00 AM - 6:00 PM",
-        "FRI": "9:00 AM - 6:00 PM",
-        "SAT": "9:00 AM - 11:00 AM,2:00 PM - 5:30 PM"
-      });
+
+    it('converts to templatable objects', function() {
+      hours.humanize().should.eql([
+        { day: 'Sunday', hours: '9:00 AM - 6:00 PM' },
+        { day: 'Monday', hours: '9:00 AM - 12:00 PM, 2:00 PM - 5:00 PM' },
+        { day: 'Tuesday', hours: '9:00 AM - 12:00 AM' },
+        { day: 'Wednesday', hours: '9:00 AM - 6:00 PM' },
+        { day: 'Thursday', hours: null },
+        { day: 'Friday', hours: '9:00 AM - 6:00 PM' },
+        { day: 'Saturday', hours: '9:00 AM - 11:00 AM, 2:00 PM - 5:30 PM' }
+      ]);
     });
 
   });
@@ -206,34 +206,4 @@ describe("Hours", function(){
     });
   });
 
-  describe("#humanizeCondensed", function() {
-    var condensed;
-
-    beforeEach(function() {
-      console.log(hours.hours);
-      condensed = hours.humanizeCondensed();
-    });
-
-    // it("should condense intervals", function() {
-    //   condensed.should.eql([
-    //     {
-    //       label: "Sunday",
-    //       interval: "9:00 AM - 6:00 PM"
-    //     },
-    //     {
-    //       label: "Monday",
-    //       interval: "9:00 AM - 5:00 PM"
-    //     },
-    //     {
-    //       label: "Tuesday - Friday",
-    //       interval: "9:00 AM - 6:00 PM"
-    //     },
-    //     {
-    //       label: "Saturday",
-    //       interval: "9:00 AM - 5:30 PM"
-    //     }
-    //   ]);
-
-    // });
-  });
 });


### PR DESCRIPTION
@zendesk/linksf 

I couldn't see a use case for collapsing something like 9am-3pm, 5pm-8pm to 9am-8pm. Instead of just taking the earliest and latest timestamps for a given day, I've prototyped an alternative interval merging algorithm:
1. for all intervals provided, collapse boundaries onto a single timeline (with start/end labeled)
2. walk through the timeline, opening/closing intervals at the lowest nesting level

Some tests fail for now, since #merge was expected to collapse intervals instead of unioning them. I'll proceed with the work in this PR if you folks are on board.

This is what the new merging algo would roughly output, for instance:
![screen shot 2013-10-02 at 12 46 58 am](https://f.cloud.github.com/assets/279406/1251741/488b8244-2b37-11e3-9544-6dedda40421a.png)
