### PR TITLE
specify node versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "Link-SF",
   "version": "v0.0.1",
-  "engines": {},
+  "engines": {
+    "node" : ">=0.10.3 <0.12"
+  },
   "devDependencies": {
     "grunt-autoprefixer": "^2.1.0",
     "grunt-aws-s3": "^0.10.0",


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#engines

@zendesk/linksf 

Specifies the supported node versions so we don't run into any issues like https://github.com/zendesk/linksf/issues/248.

cc @mydiemho