### PR TITLE
Luis/fix phone link

### DIFF
--- a/app/js/lib/features.js
+++ b/app/js/lib/features.js
@@ -1,17 +1,17 @@
 function isMobile () {
-  return window.navigator.userAgent.match(/Mobile/);
+  return /Mobile/.test(window.navigator.userAgent);
 }
 
-function isIOS() { 
-  return window.navigator.userAgent.match(/(iPad|iPhone|iPod)/g);
+function isIOS() {
+  return /(iPad|iPhone|iPod)/g.test(window.navigator.userAgent);
 }
 
 function isIE() {
-  return window.navigator.userAgent.match(/MSIE/);
+  return /MSIE/.test(window.navigator.userAgent);
 }
 
 function isAndroid22() {
-  return window.navigator.userAgent.match(/Android 2\.2/);
+  return /Android 2\.2/.test(window.navigator.userAgent);
 }
 
 var Features = {

--- a/app/js/templates/detail.hbs
+++ b/app/js/templates/detail.hbs
@@ -32,7 +32,7 @@
           <div>
             <i class="icon-phone"></i>
             <label>Call</label>
-            {{#if ../isMobile}}
+            {{#if ../../isMobile}}
               <a href="tel:{{number}}">{{number}}</a>
             {{else}}
               <span>{{number}}</span>


### PR DESCRIPTION
The link to the phone number is never rendered due to a wrong mustache path in the `detail.hbs` template.

I also did a small refactoring in the `features` module.
Seems more correct to me that the checks return booleans instead of arrays of matched strings.
I can also remove that commit if you think it might cause some issues somewhere else in the app.
