### PR TITLE
Remove master key from the global config

### DIFF
--- a/server/config/global.json.template
+++ b/server/config/global.json.template
@@ -2,7 +2,7 @@
     "applications": {
         "<%= parseAppName %>": {
             "applicationId": "<%= parseAppId %>",
-            "masterKey": "<%= parseMasterKey %>"
+            "masterKey": ""
         },
         "_default": {
           "link": "<%= parseAppName %>"


### PR DESCRIPTION
Problem:

The master key gives users access to the entire parse API with no
restrictions. Malicious users can use it to drop tables, add themselves
as admins, etc.

Solution:

Although it's not clear if `global.json` is exposing the master key on
the client (I couldn't find it after ~15 minutes), it's best to err on
the safe side and remove it from any javascript.

Removing this doesn't have any adverse affects.