### PR TITLE
Dependency & Node/NPM version fixes to package.json

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -51,7 +51,7 @@ The following accounts are optional:
 To build the site (turn a file tree into a monolithic html, js, and css file), you'll need some command line tools installed from the sites below:
 
 * [node](http://nodejs.org/)
-* [grunt](http://gruntjs.com/)
+* [grunt-cli](http://gruntjs.com/)
 * [parse](https://www.parse.com/docs/cloud_code_guide)
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-aws-s3": "^0.10.0",
     "grunt-browserify": "~3.2.1",
     "grunt-cachebuster": "~0.1.5",
-    "grunt-cli": "^0.1.13",
+    "grunt": "~0.4.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-cssmin": "~0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "Link-SF",
   "version": "v0.0.1",
-  "engines": {},
+  "engines": {
+    "node": "~0.12.0",
+    "npm": "^2.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/zendesk/linksf.git"


### PR DESCRIPTION
- Depend on `grunt` v0.4.x in package.json, not `grunt-cli`. This is the approach recommended by the Grunt docs, and avoids `peerDependencies` failures when dependencies try to install Grunt 1.0.x.
- State Node & NPM compatibility in package.json. Link-SF will not install properly with Node > 0.12.x or NPM 3+.
