### PR TITLE
Use Formspree to send feedback from static page app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+FEEDBACK_EMAIL_ADDRESS=linksf@zendesk.com

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,7 +16,6 @@ If you want to deploy the site publicly, S3 gives us free file hosting:
 
 The following accounts are optional:
 
-* [Mailgun](http://www.mailgun.com/): For capturing feedback entered in the feedback form as an email to your account.
 * [Google Analytics](http://www.google.com/analytics/): In addition to capturing useful things like user agent and traffic, we've added a couple custom events that help us keep track of how often a user connects to a service via external link (calling, visiting website, or getting directions).
 
 ### Command line tools
@@ -34,14 +33,9 @@ Download the source (via [git](git@github.com:zendesk/linksf.git) or [.zip file]
 In the project root, you'll find a `.env.example` file. Make copies of that file called `.env.dev` and `.env.prod` in the same directory. They will probably look something like this:
 
 ```
-GOOGLE_ANALYTICS_DEV_TOKEN=XXXXXX
-GOOGLE_ANALYTICS_DEV_HOST=XXXXXX
-MAILGUN_DOMAIN=XXXXXX
-MAILGUN_API_KEY=XXXXXX
+FEEDBACK_EMAIL_ADDRESS=xxxxxxx
 ...
 ```
-
-The Mailgun and Google Analytics tokens can be ignored for now, if you'd like.
 
 Keep your `.env.dev` and `.env.prod` files secret (out of source control, etc).
 
@@ -70,9 +64,10 @@ We use http://fontello.com to generate an icon bundle. [Here's a guide on how to
 
 ### Feedback form
 
+Link-SF uses [Formspree](https://formspree.io/) to send emails from the static site.
+
 If you'd like to use a feedback form:
 
-1. Setup a [Mailgun](http://www.mailgun.com/) account
-2. Add your Mailgun domain and API key to the `.env.xxx` files (see [example .env.xxx file](https://github.com/zendesk/linksf/blob/master/.env.example))
-3. Addany to/from email address you'd like to the `.env.xxx` files on the `MAILGUN_TO_EMAIL_ADDRESS` and `MAILGUN_FROM_EMAIL_ADDRESS` lines.
-4. Deploy your new changes, then check to see if your feedback form works as intended (you'll find the feedback link on the footer of the home and detail pages).
+1. Add the email address where you would like feedback form submissions to be sent to the `.env.xxx` files on the `FEEDBACK_EMAIL_ADDRESS` line (see [example .env.xxx file](https://github.com/zendesk/linksf/blob/master/.env.example))
+1. Deploy your new changes and navigate to the feedback page (you'll find the feedback link on the footer of the home and detail pages).
+1. On the feedback page, make sure to submit the form once. This will send an email asking you to confirm your email address. Confirm your email address and submit the form once more to make sure everything is working smoothly. You're all set!

--- a/pages/feedback/index.js
+++ b/pages/feedback/index.js
@@ -20,6 +20,7 @@ class FeedbackPage extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
+      submitUrl: "https://formspree.io/" + process.env.FEEDBACK_EMAIL_ADDRESS,
       name: '',
       email: '',
       subject: '',
@@ -34,16 +35,9 @@ class FeedbackPage extends React.Component {
   }
 
   handleSubmit(e) {
-    e.preventDefault()
     if (!this.state.name || !this.state.email || !this.state.subject || !this.state.message) {
+      e.preventDefault()
       this.setState({ error: 'Please fill out all fields' })
-    } else {
-      // TODO: post data to FireBase
-      console.log({ name: this.state.name,
-                    email: this.state.email,
-                    subject: this.state.subject,
-                    message: this.state.message })
-      this.setState({ name: '', email: '', subject: '', message: '', error: '' })
     }
   }
 
@@ -52,9 +46,10 @@ class FeedbackPage extends React.Component {
       <Layout>
         {this.state.error ? <Error message={this.state.error} /> : ''}
         <h4>Give us feedback</h4>
-        <form onSubmit={this.handleSubmit}>
+        <form action={this.state.submitUrl} method="POST" onSubmit={this.handleSubmit}>
           <label>Name</label>
           <TextInput
+            name="name"
             placeholder="Your name"
             value={this.state.name}
             onChange={e => this.setState({ name: e.target.value })}
@@ -62,6 +57,7 @@ class FeedbackPage extends React.Component {
           />
           <label>Email</label>
           <TextInput
+            name="email-address"
             placeholder="Your email"
             value={this.state.email}
             onChange={e => this.setState({ email: e.target.value })}
@@ -69,6 +65,7 @@ class FeedbackPage extends React.Component {
           />
           <label>Subject</label>
           <TextInput
+            name="subject"
             placeholder="Subject"
             value={this.state.subject}
             onChange={e => this.setState({ subject: e.target.value })}
@@ -76,11 +73,13 @@ class FeedbackPage extends React.Component {
           />
           <label>Message</label>
           <TextArea
+            name="message"
             placeholder="Message"
             value={this.state.message}
             onChange={e => this.setState({ message: e.target.value })}
             required
           />
+          <input type="hidden" name="_next" value="/" />
           <Button type="submit" value="Post">Submit Feedback</Button>
         </form>
       </Layout>

--- a/pages/terms/index.js
+++ b/pages/terms/index.js
@@ -124,6 +124,13 @@ class TermsPage extends React.Component {
           Anthony will not collect any personally identifiable information about you unless you
           provide it voluntarily through Link-SF’s feedback form.</p>
 
+          <h2>Information Collected by Other Services.</h2><p>Link-SF uses Formspree
+          (https://formspree.io/) to send emails from Link-SF’s feedback form. Formspree and the
+          services it uses may collect information about you that you disclose through Link-SF’s
+          feedback form. Formspree and the services it uses will not collect any personally
+          identifiable information about you unless you provide it voluntarily through Link-SF’s
+          feedback form.</p>
+
           <h2>Cookies.</h2><p>Link-SF uses cookies. A cookie is a small file placed on your computer's hard
           drive to identify you as a user, and facilitate your ongoing access to the use of Link-SF.
           St. Anthony does not use cookies to collect any personal or identifying information about

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,7 @@ const extend = require('extend');
 const webpack = require('webpack');
 const AssetsPlugin = require('assets-webpack-plugin');
 const pkg = require('./package.json');
+const Dotenv = require('dotenv-webpack');
 
 const isDebug = global.DEBUG === false ? false : !process.argv.includes('--release');
 const isVerbose = process.argv.includes('--verbose') || process.argv.includes('-v');
@@ -75,6 +76,9 @@ const config = {
       filename: 'assets.json',
       prettyPrint: true,
     }),
+    new Dotenv({
+      path: isDebug ? '.env.dev' : '.env.prod',
+    })
   ],
 
   // Options affecting the normal modules


### PR DESCRIPTION
Use [formspree](https://formspree.io/) to send email from our static website.

Todo:
- [x] update README with instructions about formspree
- [x] update terms of use with info that formspree is used to send emails
- [x] unhardcode personal email and pull from config file

/cc @zendesk/volunteer 