### PR TITLE
Added a loading icon to the home screen

### DIFF
--- a/pages/home/index.js
+++ b/pages/home/index.js
@@ -6,6 +6,7 @@ import { taxonomiesWithIcons } from '../../lib/taxonomies'
 
 import Home from '../../components/Home'
 import Layout from '../../components/Layout'
+import Loading from '../../components/Loading'
 
 
 class HomePage extends Component {
@@ -34,7 +35,7 @@ class HomePage extends Component {
 
     return (
       <Layout>
-        <Home categories={taxonomies} />
+        { taxonomies.length ? <Home categories={taxonomies} /> : <Loading /> }
       </Layout>
     )
   }


### PR DESCRIPTION
Loading icon now appears on the home screen before the taxonomies are loaded.

<img width="626" alt="screen shot 2016-10-05 at 4 52 19 pm" src="https://cloud.githubusercontent.com/assets/61457/19135782/229d5ccc-8b1c-11e6-9aeb-766908fa9a5c.png">


@zendesk/volunteer 