### PR TITLE
Redirect to admin login page and show error when login fails

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -46,7 +46,7 @@ export const destroySession = () => {
   delete sessionStorage[OAUTH_TOKEN]
 }
 
-export const login = (email, password, loginCallback) => {
+export const login = (email, password, loginSuccessCallback, loginFailureCallback) => {
   const firebase = firebaseClient()
 
   firebase
@@ -66,10 +66,9 @@ export const login = (email, password, loginCallback) => {
   firebase
     .auth()
     .signInWithEmailAndPassword(email, password)
-    .then(loginCallback)
+    .then(loginSuccessCallback)
     .catch((error) => {
-      var errorCode = error.code
-      var errorMessage = error.message
+      loginFailureCallback(error.message)
     })
 }
 

--- a/pages/auth/login.js
+++ b/pages/auth/login.js
@@ -6,22 +6,29 @@ import { redirectTo } from '../../lib/navigation'
 import Layout from '../../components/Layout'
 import Login from '../../components/Login'
 import Loading from '../../components/Loading'
+import Error from '../../components/Error'
 
 class LoginPage extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      loggingIn: false
+      loggingIn: false,
+      error: null
     }
   }
 
   handleSubmit = (email, password) => {
     this.setState({loggingIn: true})
-    login(email, password, this.loginSuccess)
+    login(email, password, this.loginSuccess, this.loginFailure)
   }
 
   loginSuccess = () => {
     redirectTo('/admin')
+  }
+
+  loginFailure = (errorMessage) => {
+    const error = "Login error: " + errorMessage
+    this.setState({loggingIn: false, error: error})
   }
 
   render() {
@@ -32,7 +39,10 @@ class LoginPage extends Component {
         {
           loggingIn ?
             <Loading /> :
-            <Login handleSubmit={this.handleSubmit} />
+            <div>
+              {this.state.error ? <Error message={this.state.error} /> : null}
+              <Login handleSubmit={this.handleSubmit} error={this.error}/>
+            </div>
         }
       </Layout>
     )


### PR DESCRIPTION
Previously, after a failure occurred logging into the admin page, the page continued to show the progress icon indefinitely. This PR changes the behavior to redirect to the login page and show an error message.

/cc @zendesk/volunteer 

<img width="1016" alt="screen shot 2016-10-12 at 4 31 49 pm" src="https://cloud.githubusercontent.com/assets/3194426/19331359/69fa4738-9099-11e6-9743-f52413174728.png">
