### PR TITLE
no more sort by name and move filter button

### DIFF
--- a/components/FilterBar/FilterBar.js
+++ b/components/FilterBar/FilterBar.js
@@ -1,18 +1,11 @@
 import React, { PropTypes } from 'react'
 import ToggleButton from '../ToggleButton'
-import Button from '../Button'
+
 import s from './FilterBar.css'
 import Link from '../Link'
 
 const FilterBar = (props) => (
   <div className={s.row}>
-    <div className={s.filterOption}>
-      <ToggleButton
-        label="Sort by name"
-        enabled={false}
-        on
-      />
-    </div>
     <div className={s.filterOption}>
       <ToggleButton
         label="Sort by distance"
@@ -27,9 +20,6 @@ const FilterBar = (props) => (
         onClick={props.onToggleOpen}
       />
     </div>
-    <Link to="/options">
-      <Button>OPTIONS</Button>
-    </Link>
   </div>
 )
 

--- a/components/Home/Home.css
+++ b/components/Home/Home.css
@@ -8,6 +8,6 @@
   font-size: 30px;
   letter-spacing: 0.6pt;
   color: rgb(51, 51, 51);
-  height: 59px;
   margin: 0;
+  margin-bottom: 20pt; /* FIXME: shouldn't need a margin here */
 }

--- a/components/Layout/Layout.css
+++ b/components/Layout/Layout.css
@@ -7,6 +7,7 @@ html {
 
 body {
   margin: 0;
+  min-width: 425px;
 }
 
 .body {
@@ -17,8 +18,6 @@ body {
 .center {
   display: flex;
   flex-flow: column nowrap;
-  justify-content: center;
-  align-items: center;
 }
 
 .contentTopSpace {
@@ -26,12 +25,14 @@ body {
 }
 
 .content {
-  width: 100%;
-  max-width: calc(750px - (28*2)px); /* CSS SUCKS BUTT, I SHOULD NOT HAVE TO DO THIS */
+  max-width: 750px;
   padding: 0 28px;
+  display: flex;
+  flex-flow: column nowrap;
 }
 
 .adminContent {
+  min-width: 320px;
   max-width: 1000px;
   width: 100%;
 }

--- a/components/Layout/Navigation.css
+++ b/components/Layout/Navigation.css
@@ -32,6 +32,9 @@
 
 .filterContainer {
   flex-basis: 33%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .back {
@@ -56,6 +59,15 @@
 
 .logoImg {
   height: 40px;
+}
+
+.filter {
+  cursor: pointer;
+  text-decoration: none;
+  color: rgb(0, 122, 255);
+  font-size: 34px;
+  display: flex;
+  align-items: center;
 }
 
 .currentUser {

--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import history from '../../core/history'
 
 import Link from '../Link'
+import Button from '../Button'
 import s from './Navigation.css'
 
 const CurrentUser = (props) => {
@@ -26,14 +27,13 @@ class Navigation extends Component {
         <div className={s.navContent}>
           <div className={s.backContainer}>
             {window.location.pathname === "/" ?
-              <span></span> :
+              null :
               <Link className={s.back} to="" onClick={history.goBack}>
                 <svg xmlns="http://www.w3.org/2000/svg" className={s.backArrow}>
                   <path d="M2.5 23 L22.5 2.5 M2.5 20 L22.5 41.5 Z"/>
                 </svg>
                 <span className={s.backText}>Back</span>
-              </Link>
-            }
+              </Link>}
           </div>
           <div className={s.logoContainer}>
             <Link to="/">
@@ -47,7 +47,9 @@ class Navigation extends Component {
             </Link>
           </div>
           <div className={s.filterContainer}>
-
+            {window.location.pathname === "/" ?
+              null :
+              <Link className={s.filter} to="/options">Filter</Link>}
           </div>
           {/*<CurrentUser { ...this.props } />*/}
         </div>


### PR DESCRIPTION
Get rid of the unused sort by name option and move the filter thingy to the right place. 

/cc @zendesk/volunteer 

![](http://content.screencast.com/users/CDay.zendesk/folders/Jing/media/2bf958c0-8f83-4605-88f9-c9366bab8724/00000332.png)