### PR TITLE
Add authentication to writes

### DIFF
--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -1,6 +1,7 @@
 import 'whatwg-fetch'
 import camelize from 'camelize'
 
+import { currentUser } from '../lib/session'
 import config from '../config'
 
 const LOCATIONS     = 'locations'
@@ -11,6 +12,9 @@ const PHONES        = 'phones'
 const SLASH         = '/'
 const FORMAT        = '.json'
 
+function authToken() {
+  return '?auth=' + currentUser().token
+}
 
 export function fetchTaxonomies() {
   const url = [
@@ -55,7 +59,7 @@ export function updateLocation(location) {
     config.firebaseDatabaseUrl,
     LOCATIONS,
     location.id
-  ].join(SLASH).concat(FORMAT)
+  ].join(SLASH).concat(FORMAT).concat(authToken())
 
   return fetch(url, {
       method: 'PUT',
@@ -111,7 +115,7 @@ export function updateOrganization(organization) {
     config.firebaseDatabaseUrl,
     ORGANIZATIONS,
     organization.id
-  ].join(SLASH).concat(FORMAT)
+  ].join(SLASH).concat(FORMAT).concat(authToken())
 
   return fetch(url, {
       method: 'PUT',

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,7 +4,6 @@ import firebase from 'firebase'
 import globalConfig from '../config'
 import { redirectTo } from './navigation'
 
-export const OAUTH_TOKEN  = 'linksf::oauthToken'
 export const CURRENT_USER = 'linksf::currentUser'
 
 
@@ -21,6 +20,7 @@ export const authenticate = () => {
 
 export const currentUser = () => {
   const sessionData = sessionStorage[CURRENT_USER]
+
   let user = null
 
   try {
@@ -43,7 +43,6 @@ export const setCurrentUser = (user) => {
 
 export const destroySession = () => {
   delete sessionStorage[CURRENT_USER]
-  delete sessionStorage[OAUTH_TOKEN]
 }
 
 export const login = (email, password, loginSuccessCallback, loginFailureCallback) => {
@@ -58,8 +57,10 @@ export const login = (email, password, loginSuccessCallback, loginFailureCallbac
           email: user.email,
           photo: user.photoUrl,
         })
-
-        setCurrentUser(userData)
+        user.getToken().then((token) => {
+          userData.token = token
+          setCurrentUser(userData)
+        })
       }
     })
 


### PR DESCRIPTION
This adds the user's authentication token to any Firebase write request.  I also restricted the DB rules in firebase to require auth for writes here https://console.firebase.google.com/project/vivid-inferno-4672/database/rules.

@zendesk/volunteer 