### PR TITLE
lazily load locations and calculate distances

### DIFF
--- a/components/FilterBar/FilterBar.js
+++ b/components/FilterBar/FilterBar.js
@@ -15,18 +15,18 @@ const getNewSortQueryString = (queryString, sortDist) => (
 const FilterBar = (props) => (
   <div className={s.row}>
     <div className={s.filterOption}>
-      <Link to="/locations" queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
-        <ToggleButton
-          label="Sort by distance"
-          enabled={props.sortDist}
-        />
-      </Link>
-    </div>
-    <div className={s.filterOption}>
       <Link to="/locations" queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
         <ToggleButton
           label="Open now"
           enabled={props.showOpen}
+        />
+      </Link>
+    </div>
+    <div className={s.filterOption}>
+      <Link to="/locations" queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
+        <ToggleButton
+          label="Sort by distance"
+          enabled={props.sortDist}
         />
       </Link>
     </div>

--- a/components/LocationRow/LocationRow.css
+++ b/components/LocationRow/LocationRow.css
@@ -57,6 +57,7 @@
   flex-wrap: nowrap;
   align-items: flex-end;
   justify-content: space-between;
+  color: rgb(153, 153, 153);
 }
 
 .sidebar {
@@ -64,8 +65,4 @@
   color: rgb(204, 204, 204);
   width: 15px;
   text-align: right;
-}
-
-.distanceText {
-  color: rgb(153, 153, 153);
 }

--- a/components/LocationRow/LocationRow.css
+++ b/components/LocationRow/LocationRow.css
@@ -56,6 +56,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: flex-end;
+  justify-content: space-between;
 }
 
 .sidebar {
@@ -65,3 +66,6 @@
   text-align: right;
 }
 
+.distanceText {
+  color: rgb(153, 153, 153);
+}

--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -82,12 +82,21 @@ function ensureDefaultsForLocations(locations) {
 }
 
 function getQueryString(pageSize, startAt) {
-  if (startAt) {
-    return `?limitToFirst=${pageSize}&startAt="${startAt}"&orderBy="$key"`
-  } else if (pageSize) {
-    return `?limitToFirst=${pageSize}&orderBy="$key"`
+  if (!pageSize && !startAt) {
+    return ''
   }
-  return ''
+
+  const queryString = ['orderBy="$key"']
+
+  if (pageSize > 0) {
+    queryString.push(`limitToFirst=${pageSize}`)
+  }
+
+  if (startAt) {
+    queryString.push(`startAt="${startAt}"`)
+  }
+
+  return `?${queryString.join('&')}`
 }
 
 export function fetchLocations(pageSize, startAt) {

--- a/pages/locations/index.js
+++ b/pages/locations/index.js
@@ -87,9 +87,11 @@ export default class LocationsPage extends Component {
           })
       }, 250)
     } else {
-      // we should have to do this, but mergeLocationsAndDistances modifies the
-      // the location, so as a side effect the state gets updated anyway
-      // this.setState({ locations: locationsWithDistance }) // if the above comment is implemented,
+      // technically the `setState` call is necessary, but
+      // mergeLocationsAndDistances modifies the location, so as a side effect
+      // the state gets updated anyway
+
+      // this.setState({ locations: locationsWithDistance })
     }
   }
 

--- a/pages/locations/index.js
+++ b/pages/locations/index.js
@@ -106,20 +106,21 @@ export default class LocationsPage extends Component {
   render() {
     const { locations } = this.state
     const loading = locations == null
-    const category = getParameterByName('categories')
     const showOpen = window.location.search.includes('hours=open')
     const sortDist = window.location.search.includes('sort=dist')
     const locationsList = Object.values(locations || {})
     const queryString = window.location.search
     const filteredLocations = filterByOptionsString(queryString.slice(1, queryString.length), locationsList)
 
-    filteredLocations.sort(function(a,b) {
-      if (a.duration && b.duration) {
-        return a.duration.value - b.duration.value
-      } else {
-        return 0
-      }
-    });
+    if (sortDist) {
+      filteredLocations.sort((a, b) => {
+        if (a.duration && b.duration) {
+          return a.duration.value - b.duration.value
+        } else {
+          return 0
+        }
+      })
+    }
 
     return (
       <Layout>


### PR DESCRIPTION
This is kind of messy, but necessary.  The Google Maps API will only allow you to request distances within the following rate limits. 

* 2,500 free elements per day, calculated as the sum of client-side and server-side queries; enable billing to access higher daily quotas, billed at $0.50 USD / 1000 additional elements, up to 100,000 elements daily.
* Maximum of 25 origins or 25 destinations per request.
* Maximum 100 elements per request.
* Maximum 100 elements per second, calculated as the sum of client-side and server-side queries.

This PR lazily loads the locations, 25 before render, the rest after. Once all locations have been loaded, it will then make the necessary calls with the necessary rate limits to compute the distance to each location. 

Here is a shitty gif, but you can see it happen after the page refresh.
![](http://g.recordit.co/2FSkxXHCK9.gif)

/cc @zendesk/volunteer 