### PR TITLE
Options page search link updates

### DIFF
--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -20,10 +20,9 @@ const CurrentUser = (props) => {
 }
 
 const getFilter = () => {
-  if(window.location.pathname ==='/')
-    return null;
-  else if(window.location.pathname === '/options')
-    return <Link className={s.filter} to="/options">Search</Link>
+  const pathname = window.location.pathname
+  if((pathname === '/') || (pathname === '/options'))
+    return null
   else
     return <Link className={s.filter} to="/options">Filter</Link>
 }

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -94,18 +94,17 @@
 }
 
 .searchButton {
-  background-color: #F3F3F3;
-  background-image: linear-gradient(white,#EBEBEB);
+  background-color: #FFFFFF;
   border: 1px solid #DCDCDC;
-  border-radius: 13px;
-  color: #989898;
-  font-size: 8px;
+  border-radius: 4px;
+  color: #666;
   padding: 4px 7px;
   width: 100%;
   text-align: center;
   text-shadow: none;
-  height: 25px;
-  font-size: 10px;
+  height: 36px;
+  font-size: 20px;
+  margin-top: 8px;
 }
 
 .alert {


### PR DESCRIPTION
Makes the following updates to the options page:

* removes search link in top right of page that was not fully implemented
* updates styling of search button on bottom of page to be consistent with rest of page

/cc @zendesk/volunteer 

Before:
<img width="851" alt="screen shot 2016-11-30 at 5 42 25 pm" src="https://cloud.githubusercontent.com/assets/3194426/20778757/ce3793fc-b724-11e6-8cd7-3568b0bf9e4f.png">

After (updated):
<img width="846" alt="screen shot 2016-12-01 at 11 29 59 am" src="https://cloud.githubusercontent.com/assets/3194426/20809066/b5402658-b7b9-11e6-9ae4-f3ae60124ec8.png">

