### PR TITLE
Unsquash logos on the about page

### DIFF
--- a/pages/about/about.css
+++ b/pages/about/about.css
@@ -13,7 +13,7 @@
 
 .logo {
   margin: 15px 5px 5px 8px;
-  height: 25px;
+  width: 200px;
 }
 
 .credits {


### PR DESCRIPTION
Logos on the about page were being stretched out across the width of the screen due to static height; set a width instead to keep them in proportion