### PR TITLE
Actually use locations for map

### DIFF
--- a/components/GoogleMap/GoogleMap.js
+++ b/components/GoogleMap/GoogleMap.js
@@ -2,15 +2,6 @@ import React, { PropTypes } from 'react'
 
 import { GoogleMapLoader, GoogleMap, Marker } from 'react-google-maps'
 
-const markers = [{
-  position: {
-    lat: 37.774,
-    lng: -122.4194,
-  },
-  key: 'Taiwan',
-  defaultAnimation: 2,
-}]
-
 const MyGoogleMap = (props) => {
   return (
     <GoogleMapLoader
@@ -23,7 +14,7 @@ const MyGoogleMap = (props) => {
       }
       googleMapElement={
         <GoogleMap
-          defaultCenter={{ lat: 37.774, lng: -122.4194 }}
+          defaultCenter={{ lat: props.lat, lng: props.long }}
           options={{
             zoom:              15,
             mapTypeControl:    false,
@@ -34,13 +25,10 @@ const MyGoogleMap = (props) => {
             zoomControl:       false
           }}
         >
-          {markers.map((marker, index) => {
-            return (
-              <Marker
-                {...marker}
-                onRightclick={() => props.onMarkerRightclick(index)} />
-            )
-          })}
+        <Marker
+          position={{ lat: props.lat, lng: props.long }}
+          defaultAnimation={2}
+         />
         </GoogleMap>
       }
     />

--- a/components/Location/Location.js
+++ b/components/Location/Location.js
@@ -197,7 +197,7 @@ const Location = (props) => {
       {location.physicalAddress &&
         <div className={s.insetMap}>
           <div className={s.map}>
-            <GoogleMap />
+            <GoogleMap lat={location.latitude} long={location.longitude} />
           </div>
           <p className={s.address}>
             {location.physicalAddress.address1}


### PR DESCRIPTION
Looks like we had some copy-pasta Google Maps code which was using a hard coded value for the map.  This should switch to actually using the Location's location.

**Before**
![](http://content.screencast.com/users/pididiot1/folders/Jing/media/04d9e86d-af89-438d-9086-a73da7c42483/00000091.png)

**After**
![](http://content.screencast.com/users/pididiot1/folders/Jing/media/b0a165e7-df80-4c46-a043-389511a1bbf6/00000090.png)

@zendesk/volunteer 