### PR TITLE
Use slightly more semantic markup for filter btns

### DIFF
--- a/components/FilterBar/FilterBar.js
+++ b/components/FilterBar/FilterBar.js
@@ -17,6 +17,7 @@ const FilterBar = (props) => (
     <div className={s.filterOption}>
       <Link to="/locations" queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
         <ToggleButton
+          visualOnly={true} // <span> instead of <button> as we're in a <Link>
           label="Open now"
           enabled={props.showOpen}
         />
@@ -25,6 +26,7 @@ const FilterBar = (props) => (
     <div className={s.filterOption}>
       <Link to="/locations" queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
         <ToggleButton
+          visualOnly={true}
           label="Sort by distance"
           enabled={props.sortDist}
         />

--- a/components/ToggleButton/ToggleButton.js
+++ b/components/ToggleButton/ToggleButton.js
@@ -1,14 +1,35 @@
 import React from 'react'
 import s from './ToggleButton.css'
 
-const ToggleButton = (props) => (
-  <button
-    className={`${s.toggleButton} ${props.enabled ? s.enabled : ''} ${props.extraClasses}`}
-    onClick={props.onClick}
-    title={props.label}
-  >
-  {props.label}
-  </button>
-)
+// A button with toggle classes based on state and
+// either a visual-only display (for putting inside of an a link)
+// or onClick support (which will render as a button)
+const ToggleButton = (props) => {
+  const className = `${s.toggleButton}
+                     ${props.enabled ? s.enabled : ''}
+                     ${props.extraClasses || ''}`;
+
+  if (props.visualOnly) {
+    return (
+      <span
+        className={className}
+        // No onClick support - use button for that
+        title={props.label}
+      >
+        {props.label}
+      </span>
+    )
+  } else {
+    return (
+      <button
+        className={className}
+        onClick={props.onClick}
+        title={props.label}
+      >
+        {props.label}
+      </button>
+    )
+  }
+}
 
 export default ToggleButton


### PR DESCRIPTION
This will result in an `<a href …><span>…</></>` DOM structure instead of  `<a href …><button>…</></>`, which is a bit better from a markup and probably acessibility (a11y) standpoint.