### PR TITLE
Placeholder text for location address autocomplete field

### DIFF
--- a/components/LocationEdit/LocationEdit.css
+++ b/components/LocationEdit/LocationEdit.css
@@ -32,6 +32,7 @@
   vertical-align: middle;
   box-shadow: inset 0 1px 2px #ddd;
   color: #777;
+  width: 250px;
 }
 
 .sectionLabel {

--- a/components/LocationEdit/LocationEdit.js
+++ b/components/LocationEdit/LocationEdit.js
@@ -20,6 +20,14 @@ const blankService = (location) => ({
   taxonomy: ""
 })
 
+const placeholderAddressText = (physicalAddress) => {
+  if (physicalAddress.address1) {
+    return physicalAddress.address1 + ", " + physicalAddress.city;
+  } else {
+    return "Search for location"
+  }
+}
+
 class LocationEdit extends Component {
    updateLocation = (field, value) => {
     const { index, location, handleChange } = this.props
@@ -119,8 +127,9 @@ class LocationEdit extends Component {
         </div>
         <div className={s.inputBox}>
           <div className={s.inputGroup}>
-            <span className={s.inputLabel}>Street Address</span>
+            <span className={s.inputLabel}>Location Address</span>
             <Autocomplete
+              placeholder={placeholderAddressText(location.physicalAddress)}
               className={s.input}
               onPlaceSelected={this.handleAddress}
               types={['geocode']}
@@ -136,7 +145,7 @@ class LocationEdit extends Component {
             />
           </div>
           <div className={s.inputGroup}>
-            <span className={s.inputLabel}>City </span>
+            <span className={s.inputLabel}>City</span>
             <input
               className={s.input}
               type="text"


### PR DESCRIPTION
When a location exists, show the current location as the placeholder text for the google search location autocomplete field.

/cc @zendesk/volunteer 

### Before

Editing existing location

<img width="860" alt="screen shot 2017-01-04 at 3 17 01 pm" src="https://cloud.githubusercontent.com/assets/3194426/21662806/e13e6bf6-d290-11e6-9e76-75f94ba9d28e.png">

Add new location

<img width="852" alt="screen shot 2017-01-04 at 3 17 07 pm" src="https://cloud.githubusercontent.com/assets/3194426/21662808/e238937e-d290-11e6-8a64-b2eb52968a5e.png">

### Now

Editing existing location

<img width="851" alt="screen shot 2017-01-04 at 3 14 53 pm" src="https://cloud.githubusercontent.com/assets/3194426/21662786/c1c97a40-d290-11e6-96a1-69135042f8ec.png">

Add new location

<img width="851" alt="screen shot 2017-01-04 at 3 15 01 pm" src="https://cloud.githubusercontent.com/assets/3194426/21662788/c3cde6b4-d290-11e6-9c75-202d2876adfd.png">
