### PR TITLE
Use replaceState for filter links

### DIFF
--- a/components/FilterBar/FilterBar.js
+++ b/components/FilterBar/FilterBar.js
@@ -15,7 +15,7 @@ const getNewSortQueryString = (queryString, sortDist) => (
 const FilterBar = (props) => (
   <div className={s.row}>
     <div className={s.filterOption}>
-      <Link to="/locations" queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
+      <Link to="/locations" replaceState={true} queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
         <ToggleButton
           visualOnly={true} // <span> instead of <button> as we're in a <Link>
           label="Open now"
@@ -24,7 +24,7 @@ const FilterBar = (props) => (
       </Link>
     </div>
     <div className={s.filterOption}>
-      <Link to="/locations" queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
+      <Link to="/locations" replaceState={true} queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
         <ToggleButton
           visualOnly={true}
           label="Sort by distance"

--- a/components/FilterBar/FilterBar.js
+++ b/components/FilterBar/FilterBar.js
@@ -15,7 +15,7 @@ const getNewSortQueryString = (queryString, sortDist) => (
 const FilterBar = (props) => (
   <div className={s.row}>
     <div className={s.filterOption}>
-      <Link to="/locations" replaceState={true} queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
+      <Link to="/locations" replaceState queryString={getNewFilterQueryString(props.queryString, !props.showOpen)}>
         <ToggleButton
           visualOnly={true} // <span> instead of <button> as we're in a <Link>
           label="Open now"
@@ -24,7 +24,7 @@ const FilterBar = (props) => (
       </Link>
     </div>
     <div className={s.filterOption}>
-      <Link to="/locations" replaceState={true} queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
+      <Link to="/locations" replaceState queryString={getNewSortQueryString(props.queryString, !props.sortDist)}>
         <ToggleButton
           visualOnly={true}
           label="Sort by distance"

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -1,7 +1,8 @@
 import React, { Component, PropTypes } from 'react'
+import R from 'ramda'
 
 import history from '../../core/history'
-import { redirectTo, convertToQueryString } from '../../lib/navigation'
+import { redirectTo, redirectToViaReplace, convertToQueryString } from '../../lib/navigation'
 
 
 class Link extends Component {
@@ -31,19 +32,21 @@ class Link extends Component {
     event.preventDefault()
 
     const queryString = this.props.queryString || convertToQueryString(this.props.query)
+    const go = this.props.replaceState ? redirectToViaReplace : redirectTo;
 
     if (this.props.to && (this.props.query || this.props.queryString)) {
-      redirectTo({
+      go({
         pathname: this.props.to,
         search: queryString
       })
     } else if (this.props.to) {
-      redirectTo(this.props.to)
+      go(this.props.to)
     }
   }
 
   render() {
-    const { to, query, queryString, ...props } = this.props; // eslint-disable-line no-use-before-define
+    const propsForChild = R.omit(['replaceState'], this.props);
+    const { to, query, queryString, ...props } = propsForChild // eslint-disable-line no-use-before-define
     return <a href={history.createHref(to)} {...props} onClick={this.handleClick} />
   }
 

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -32,7 +32,7 @@ class Link extends Component {
     event.preventDefault()
 
     const queryString = this.props.queryString || convertToQueryString(this.props.query)
-    const go = this.props.replaceState ? redirectToViaReplace : redirectTo;
+    const go = (this.props.replaceState ? redirectToViaReplace : redirectTo)
 
     if (this.props.to && (this.props.query || this.props.queryString)) {
       go({
@@ -45,7 +45,7 @@ class Link extends Component {
   }
 
   render() {
-    const propsForChild = R.omit(['replaceState'], this.props);
+    const propsForChild = R.omit(['replaceState'], this.props)
     const { to, query, queryString, ...props } = propsForChild // eslint-disable-line no-use-before-define
     return <a href={history.createHref(to)} {...props} onClick={this.handleClick} />
   }

--- a/lib/navigation.js
+++ b/lib/navigation.js
@@ -3,6 +3,10 @@ import history from '../core/history'
 export const redirectTo = (location) => {
   history.push(location)
 }
+export const redirectToViaReplace = (location) => {
+  // Use 'replace' instead of 'push' so that the 'back' button skips filter changes
+  history.replace(location)
+}
 
 const EMPTY_QUERY = {
   sortBy: '',


### PR DESCRIPTION
Addresses #376 the easy way. The back button still invokes the browser history, but now changing filter options won't push items onto the history.

Demoed to Craig & Adam 2017-01-04 5:29 PM 