### PR TITLE
Update filter for category

### DIFF
--- a/components/Category/Category.js
+++ b/components/Category/Category.js
@@ -6,7 +6,7 @@ import icons from '../../icons/css/icons.css'
 const category = (props) => (
   <Link
     to="/locations"
-    query={{ services: [props.name.toLowerCase()] }}
+    query={{ services: [props.id] }}
     className={s.category}
     aria-label={`Look for ${props.name} services`}
   >


### PR DESCRIPTION
Filter for categories to be based on taxonomy id, not the lowercased name.

Our ported taxonomies ended up camelcased, so clicking on a taxonomy from the home page wouldn't work. 