### PR TITLE
Display '24 hours' for services instead of time range

### DIFF
--- a/components/Location/Location.js
+++ b/components/Location/Location.js
@@ -142,9 +142,13 @@ const getDailySchedules = (schedules) => {
   return daySchedules
 }
 
-const getTimeRange = hours => (
-  `${convertMilitaryTime(hours.opensAt)} - ${convertMilitaryTime(hours.closesAt)}`
-)
+const getTimeRange = hours => {
+  if (hours.opensAt == 0 && hours.closesAt == 2359 ) {
+    return `24 hours`
+  } else {
+    return `${convertMilitaryTime(hours.opensAt)} - ${convertMilitaryTime(hours.closesAt)}`
+  }
+}
 
 const Schedule = (props) => {
   const daySchedules = getDailySchedules(props.schedules)


### PR DESCRIPTION
/cc @zendesk/volunteer 

Replaces `12am-11:59pm` with `24 hours`

![](https://content.screencast.com/users/cherub213/folders/Jing/media/42a89bd3-1bc1-4bf9-9c01-5c8ceb7ce14d/00000081.png)