### PR TITLE
Convert new lines to spaces in the services description

### DIFF
--- a/components/Location/Location.js
+++ b/components/Location/Location.js
@@ -8,6 +8,8 @@ import { capitalize } from '../../lib/stringHelpers'
 import Link from '../Link'
 import GoogleMap from '../GoogleMap'
 
+const nl2br = require('react-nl2br');
+
 const getGender = (abbr) => {
   if (abbr === '' || abbr === 'MF' || abbr === 'FM') return 'Everyone'
   return abbr === 'F' ? 'Women' : 'Men'
@@ -252,7 +254,7 @@ const Location = (props) => {
           <li key={`service-${index}`} className={s.insetServices}>
             <div className={s.noteWrapper}>
               <h3 className={s.serviceTitle}>{service.name}</h3>
-              <p className={s.serviceDescription}>{service.description}</p>
+              <p className={s.serviceDescription}>{nl2br(service.description)}</p>
               <Schedule schedules={service.schedules} />
             </div>
             <div className={s.notes}>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^15.2.0",
     "react-google-autocomplete": "^1.0.7",
     "react-google-maps": "^4.11.0",
+    "react-nl2br": "^0.2.0",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "whatwg-fetch": "^1.0.0"


### PR DESCRIPTION
Adds a simple new library to convert new lines to <br/> and used on the services description:

![](https://content.screencast.com/users/cherub213/folders/Jing/media/26e82289-c76a-4118-abff-d40344baf583/00000082.png) 