### PR TITLE
Fixed geo location bug for Safari

### DIFF
--- a/pages/options/index.js
+++ b/pages/options/index.js
@@ -67,12 +67,9 @@ class OptionsPage extends Component {
 
   getGeoPermission() {
     const self = this
-    navigator.permissions.query({ name: 'geolocation' })
-      .then(function(permission) {
-        if (permission.state === 'granted') {
-          self.setState({ showGeoAlert: false })
-        }
-      })
+    navigator.geolocation.getCurrentPosition(function() {
+      self.setState({ showGeoAlert: false })
+    })
   }
 
   setSortBy(sortBy) {
@@ -153,7 +150,7 @@ class OptionsPage extends Component {
                 disableButton={'disabled'}
               />
             </Group>
-            <div className={`${s.alert} ${showGeoAlert ? s.hide : ''}`}>
+            <div className={`${s.alert} ${showGeoAlert ? '' : s.hide}`}>
               <strong>Distance disabled:</strong> current location unavailable
             </div>
           </ButtonGroup>

--- a/pages/options/options.css
+++ b/pages/options/options.css
@@ -31,7 +31,7 @@
   min-height: 25px;
   padding: 10px 0 10px 5px;
   color: #999999;
-  flex: 1 100%;
+  flex: 1;
 }
 
 .button:last-child {


### PR DESCRIPTION
- Using geolocation.getCurrentPosition instead of navigator
- It will set show message false if currentPosition returns a success response
- Fixed small css issue in options page in Safari

![image](https://user-images.githubusercontent.com/16842851/26904528-2dbdc998-4b97-11e7-804a-fcdf433e709c.png)
