### PR TITLE
Fix new org.

### DIFF
--- a/components/OrganizationEdit/OrganizationEdit.js
+++ b/components/OrganizationEdit/OrganizationEdit.js
@@ -149,7 +149,13 @@ class OrganizationEdit extends Component {
   }
 
   newPhone = () => {
+
     const { organization } = this.state
+
+    if(organization.phones === undefined) {
+      organization.phones = [];
+    }
+
     const newPhones = [...organization.phones]
     const newOrganization = {}
 
@@ -318,7 +324,7 @@ class OrganizationEdit extends Component {
           </button>
         </div>
         <div className={s.phonesBox}>
-          {organization.phones.map((phone, index) => (
+          {organization.phones && organization.phones.map((phone, index) => (
             <PhoneEdit
               key={`phone-${index}`}
               phone={phone}


### PR DESCRIPTION
The new organization page,
/admin/organizations/new
wasn't showing:

![new-organization-page-fix](https://user-images.githubusercontent.com/552447/28758045-9a00d8ea-754d-11e7-8b3c-3a34df2f07b1.png)

Issue was the mapping of an array that was undefined (organization.phones, which didn't exist).  Updated code on both the render and the newPhone method.

/cc @zendesk/volunteer