### PR TITLE
Load orgs inside location promise

### DIFF
--- a/pages/admin/organization.js
+++ b/pages/admin/organization.js
@@ -12,7 +12,8 @@ const blankOrganization = () => ({
   id: uuid(),
   longDescription: "",
   name: "",
-  url: ""
+  url: "",
+  phones: []
 })
 
 class OrganizationAdminPage extends Component {

--- a/pages/location/index.js
+++ b/pages/location/index.js
@@ -24,10 +24,10 @@ export default class LocationPage extends Component {
     fetchLocation(locationId)
       .then(location => {
         this.setState({ location })
-      })
-    fetchOrganization(location.organizationId)
-      .then(organization => {
-        this.setState({ organization })
+        fetchOrganization(location.organizationId)
+          .then(organization => {
+            this.setState({ organization })
+          })
       })
   }
 


### PR DESCRIPTION
The location page was all broken because it was trying to load a single organization with an id of `undefined`.  The result was an array of every organization (no bueno).

@zendesk/volunteer 