### PR TITLE
Fix several init bugs and improve the docs

### DIFF
--- a/database.seed.json
+++ b/database.seed.json
@@ -1,0 +1,9 @@
+{
+  "taxonomies" : {
+    "food" : "1",
+    "housing" : "1",
+    "hygiene" : "1",
+    "medical" : "1",
+    "technology" : "1"
+  }
+}

--- a/docs/MANAGE.md
+++ b/docs/MANAGE.md
@@ -42,9 +42,9 @@ Services contain basic information such as a name, description, and category, as
 #### Set up a Firebase user
 
 1. Navigate to the Authentication page of your [Firebase Console](https://firebase.google.com/console).
-2. Make sure you have Email/Password authentication enabled.  It should prompt you to enable it if you hover over *ADD USER*, otherwise you can find the setting under the *SIGN-IN METHOD* tab near the top of the page.
-3. Click *ADD USER* and set your email and password.
-4. That's it!  You should now be able to log in as your administrator user by visiting `/admin` either locally or on your production site.
+1. Make sure you have Email/Password authentication enabled.  It should prompt you to enable it if you hover over *ADD USER*, otherwise you can find the setting under the *SIGN-IN METHOD* tab near the top of the page.
+1. Click *ADD USER* and set your email and password.
+1. That's it!  You should now be able to log in as your administrator user by visiting `/admin` either locally or on your production site.
 
 #### Adding new data
 

--- a/docs/MANAGE.md
+++ b/docs/MANAGE.md
@@ -39,6 +39,13 @@ Services contain basic information such as a name, description, and category, as
 
 ### How to change your data
 
+#### Set up a Firebase user
+
+1. Navigate to the Authentication page of your [Firebase Console](https://firebase.google.com/console).
+2. Make sure you have Email/Password authentication enabled.  It should prompt you to enable it if you hover over *ADD USER*, otherwise you can find the setting under the *SIGN-IN METHOD* tab near the top of the page.
+3. Click *ADD USER* and set your email and password.
+4. That's it!  You should now be able to log in as your administrator user by visiting `/admin` either locally or on your production site.
+
 #### Adding new data
 
 Adding new data is as simple as clicking the "Add Organization" button in the upper right of your admin page.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -10,7 +10,7 @@ Link-SF is designed to be free to setup and free to run. Since hosting files is 
 
 * [Firebase](https://firebase.google.com/console):  Firebase is the only required account, and it's completely free.  It will provide everything we need to get up and running, including database storage, authentication, and hosting.
 
-  **Note**  Every administrator on your account will need to be created under the Authentication panel in your new Firebase Console.  You won't be able to adjust your production data from the app without it!
+  **Note**  Every administrator on your account will need to be created under the Authentication panel in your new Firebase Console.  You won't be able to adjust your production data from the app without it!  For information on how to set up users, see the [Management documentation](https://github.com/zendesk/linksf/blob/master/docs/MANAGE.md) under *Set up a Firebase user*.
 
 The following accounts are optional:
 
@@ -21,14 +21,6 @@ The following accounts are optional:
 Download the source (via [git](git@github.com:zendesk/linksf.git) or [.zip file](https://github.com/zendesk/linksf/archive/master.zip)).
 
 ## Setup
-
-### Database Population
-
-If you have an existing project hosted with Parse, you can use our migration tool to copy all of your data into  Firebase.
-
- * [Link Migrator](http://linkmigrator.herokuapp.com/)
-
-To see more about how your data is structured and what it means, read our [Management documentation](https://github.com/zendesk/linksf/blob/master/docs/MANAGE.md)
 
 ### Configuration
 
@@ -64,7 +56,7 @@ In the project root, you will find three configuration files:
 
 ### Install tools
 
-If you are working from a Unix system with Bash, you can use the pre-written boostrap script, which will complete all remaining steps in this doc.
+If you are working from a Unix system with Bash, you can use the pre-written boostrap script.  If you do, you can skip to [Database Population](#database-population).
 
 `./script/bootstrap`
 
@@ -103,6 +95,38 @@ The following steps will use Firebase Tools to authenticate and set up your loca
   This will configure which project we deploy to. Choose the correct one at the prompt and give it a nickname.
 
   `firebase use --add`
+
+### Initializing your Firebase database
+
+The following steps can be done automattically by running `./script/seed`, but if you prefer to run them manually here they are!
+
+1. Set your database permissions
+
+  To configure the proper database permissions and indexes, we've provided a JSON file named `database.rules.json`.  You can copy the config by running this:
+
+  `firebase deploy --only database`
+
+2. Seed your database
+
+  **NOTE** Running this command will overwrite all existing data in your Firebase!
+
+  To get you started with a few pre-made service categories, you can seed your database using `database.seed.json`.  
+
+  `firebase database:set / database.seed.json`
+
+### Database Population
+
+#### Migrating from Parse
+
+If you have an existing project hosted with Parse, you can use our migration tool to copy all of your data into  Firebase.
+
+ * [Link Migrator](http://linkmigrator.herokuapp.com/)
+
+#### Starting from scratch
+
+If you're starting from scratch, run `./script/seed`.  This will set the proper database configuration and seed your service categories.
+
+To see more about how your data is structured and what it means, read our [Management documentation](https://github.com/zendesk/linksf/blob/master/docs/MANAGE.md).
 
 ## Running the site locally
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -10,7 +10,7 @@ Link-SF is designed to be free to setup and free to run. Since hosting files is 
 
 * [Firebase](https://firebase.google.com/console):  Firebase is the only required account, and it's completely free.  It will provide everything we need to get up and running, including database storage, authentication, and hosting.
 
-  **Note**  Every administrator on your account will need to be created under the Authentication panel in your new Firebase Console.  You won't be able to adjust your production data from the app without it!  For information on how to set up users, see the [Management documentation](https://github.com/zendesk/linksf/blob/master/docs/MANAGE.md) under *Set up a Firebase user*.
+  **Note**  Every administrator on your account will need to be created under the Authentication panel in your new Firebase Console.  You won't be able to adjust your production data from the app without it!  For information on how to set up users, see the [Management documentation](linksf/blob/master/docs/MANAGE.md) under *Set up a Firebase user*.
 
 The following accounts are optional:
 
@@ -30,7 +30,7 @@ In the project root, you will find three configuration files:
 
   In `.firebaserc`, you will need to replace all instances of `[PROJECT_ID]` with your own Project ID, which can be found in your [Firebase Console](https://firebase.google.com/console) general settings.  This file contains aliases for various deploy destinations.  For example, if you wanted to have a testing environment and a production environment, you could set the two different Firebase Project IDs here.
 
-2. `config.js`
+1. `config.js`
 
   `config.js` contains a variety of details and keys.  Here's what you need to do:
   * Customize your project's title and description.
@@ -38,7 +38,7 @@ In the project root, you will find three configuration files:
   * Fill in your Firebase API Key in the `[FIREBASE_API_KEY]` slot, which can be found on the same page as your Project ID.
   * Enter the email address you'd like to receive feedback at (for more information see the Feedback form section below).
 
-3. `run.js`
+1. `run.js`
 
   Near the top, there will be a configuration section that looks like this:
 
@@ -56,7 +56,7 @@ In the project root, you will find three configuration files:
 
 ### Install tools
 
-If you are working from a Unix system with Bash, you can use the pre-written boostrap script.  If you do, you can skip to [Database Population](#database-population).
+If you are working from a Unix system with Bash, you can use the pre-written boostrap script and skip directly to [Database Population](#database-population).
 
 `./script/bootstrap`
 
@@ -66,11 +66,11 @@ Otherwise follow the steps below for your system.
 
   If you are using a version manager such as nvm, run `nvm install`, otherwise download and install the current version from `.nvmrc` from [the node website](http://nodejs.org/).
 
-2. Install our package manager (npm)
+1. Install our package manager (npm)
 
   Follow the installation instructions from [the npm repository](https://github.com/npm/npm).
 
-3. Install Firebase Tools
+1. Install Firebase Tools
 
   Follow the installation instructions from the [Firebase Tools repository](https://github.com/firebase/firebase-tools).
 
@@ -90,7 +90,7 @@ The following steps will use Firebase Tools to authenticate and set up your loca
 
   `firebase login`
 
-2. Add your Firebase project
+1. Add your Firebase project
 
   This will configure which project we deploy to. Choose the correct one at the prompt and give it a nickname.
 
@@ -106,7 +106,7 @@ The following steps can be done automattically by running `./script/seed`, but i
 
   `firebase deploy --only database`
 
-2. Seed your database
+1. Seed your database
 
   **NOTE** Running this command will overwrite all existing data in your Firebase!
 
@@ -151,5 +151,5 @@ Link-SF uses [Formspree](https://formspree.io/) to send emails from the static s
 If you'd like to use a feedback form:
 
 1. Add the email address where you would like feedback form submissions to be sent to in `config.js` under `[FEEDBACK_EMAIL_ADDRESS]`.
-2. Deploy your new changes and navigate to the feedback page (you'll find the feedback link on the footer of the home and detail pages).
-3. On the feedback page, make sure to submit the form once. This will send an email asking you to confirm your email address. Confirm your email address and submit the form once more to make sure everything is working smoothly. You're all set!
+1. Deploy your new changes and navigate to the feedback page (you'll find the feedback link on the footer of the home and detail pages).
+1. On the feedback page, make sure to submit the form once. This will send an email asking you to confirm your email address. Confirm your email address and submit the form once more to make sure everything is working smoothly. You're all set!

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -53,3 +53,5 @@ try "Installing Firebase Tools" "npm install -g firebase-tools"
 try "Logging you into Firebase" "firebase login"
 
 try "Choose your Firebase project" "firebase use --add"
+
+try "Initializing your Firebase database configuration" "firebase deploy --only database"

--- a/script/seed
+++ b/script/seed
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+heading() {
+  echo "$1...";
+}
+
+pass() {
+  echo "DONE"
+}
+
+fail() {
+  echo "FAIL"
+}
+
+fail_and_exit() {
+  fail
+  exit -1
+}
+
+try() {
+  heading "$1"
+  if eval "$2"
+  then
+    pass
+  else
+    fail_and_exit
+  fi
+}
+
+try "Initializing your Firebase database configuration" "firebase deploy --only database"
+
+try "Seeding your Firebase database" "firebase database:set / database.seed.json"


### PR DESCRIPTION
Here are some of the things that I found while re-following the on-boarding process this afternoon.  It should make life a little easier.

1. Adds better documentation on how to set up an administrator Firebase user.
2. Pushes the database rules before requiring a full Firebase deploy.  This is one of the issues Scott reported.
3. Adds some seed taxonomies to allow locations to actually be added.  They error out without any taxonomies present, and we have no UI for that yet.

@zendesk/volunteer 