### PR TITLE
ensure we have an id when deleting an org

### DIFF
--- a/components/OrganizationEdit/OrganizationEdit.js
+++ b/components/OrganizationEdit/OrganizationEdit.js
@@ -112,7 +112,7 @@ class OrganizationEdit extends Component {
 
     if (answer) {
       deleteOrganization(organization.id)
-        .then(redirectTo('/admin'))
+        .then(() => redirectTo('/admin'))
     }
   }
 

--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -215,11 +215,13 @@ export function updateOrganization(organization) {
 }
 
 export function deleteOrganization(id) {
+  if (!id) { return }
+
   const url = [
     config.firebaseDatabaseUrl,
     ORGANIZATIONS,
     id
-  ].join(SLASH).concat(FORMAT)
+  ].join(SLASH).concat(FORMAT).concat(authToken())
 
   return fetch(url, {method: 'DELETE'})
 }


### PR DESCRIPTION
This turns out to be how we allow someone to delete the entire organizations key. There is a race condition introduced by the incorrect use of of the `.then` callback. Instead of being a callback, we would redirect as soon as the delete request was submitted. This means we would fetch a list of organizations at the same time as deleting one. The GET request for organizations was actually issued before the DELETE due to the way that `.fetch().then()` evaluates. 

<img width="872" alt="screen shot 2017-12-20 at 2 36 00 pm" src="https://user-images.githubusercontent.com/6731804/34232022-43007260-e593-11e7-8154-86acbb1e04b1.png">

This results in the list of organizations being populated with the recently deleted org. If you then select the same org again, you will be navigated to a page with no information, just an empty org. When navigating to this page, we try to fetch the org ID which was just deleted, and it doesn't exist. So now the state contains an organization with no field, meaning no ID. 

Now comes the second bug. If you would click delete on this page, we would happily submit a delete request to `DELETE /organizations/.json`. Since browsers are friendly, they realize that last slash doesn't do anything and it gets evaluated as `DELETE /organizations.json` ... 😢 so the entire organizations key has now been deleted. 

This PR resolves the race condition by correctly using the `.then` callback, and also adds a guard clause to ensure we have an id when trying to delete an org. 

It also adds the auth token to the delete request because it is needed if you have your rules configured to require auth on writes. 

Fixes #409 

/cc @zendesk/volunteer @zendesk/linksf 