### PR TITLE
ensure we have an id for mutations

### DIFF
--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -144,6 +144,8 @@ export function fetchLocation(id) {
 }
 
 export function updateLocation(location) {
+  if (!location.id) { return }
+
   const url = [
     config.firebaseDatabaseUrl,
     LOCATIONS,
@@ -163,6 +165,8 @@ export function updateLocation(location) {
 }
 
 export function deleteLocation(id) {
+  if (!id) { return }
+
   const url = [
     config.firebaseDatabaseUrl,
     LOCATIONS,
@@ -196,6 +200,8 @@ export function fetchOrganization(id) {
 }
 
 export function updateOrganization(organization) {
+  if (!organization.id) { return }
+
   const url = [
     config.firebaseDatabaseUrl,
     ORGANIZATIONS,


### PR DESCRIPTION
As a followup to #410, this adds a simple guard to ensure we have a valid object with an ID before we try to update or delete it. 

/cc @zendesk/volunteer 