### PR TITLE
add sentry for error tracking

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -12,6 +12,8 @@
   </head>
   <body>
     <div id="container"></div>
+    <script src="https://cdn.ravenjs.com/3.21.0/raven.min.js" crossorigin="anonymous"></script>
+    <script>Raven.config('https://67fab86a4ee141c9bb047a5f9561840a@sentry.io/262361').install();</script>
     <script src="<%= bundle %>"></script>
     <%_ if (!debug && config.trackingID) { _%>
     <script>


### PR DESCRIPTION
This adds sentry.io for error tracking. I know we have a few bugs with undefined or null values, so hopefully this will help us narrow them down. 

/cc @zendesk/volunteer @zendesk/linksf 