### PR TITLE
fix the right caret on admin page

### DIFF
--- a/components/OrganizationRow/OrganizationRow.js
+++ b/components/OrganizationRow/OrganizationRow.js
@@ -21,7 +21,7 @@ const OrganizationRow = (props) => (
               {props.organization.long_description}
             </div>
             <div className="organization-item-box-caret">
-              <i className={`${icons.iconRightOpen2} s.rightCaret`}></i>
+              <i className={`${icons.iconRightOpen2} s.rightCaret icon-right-open-2`}></i>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fix the icon on the admin index page. 

This is a hack until #413 is resolved. 

![screen shot 2017-12-21 at 10 20 53 am](https://user-images.githubusercontent.com/6731804/34269319-aa318988-e638-11e7-8d6e-4a525125fb3a.png)

/cc @zendesk/volunteer @zendesk/linksf 