### PR TITLE
Default Location Services to object and not array

### DIFF
--- a/components/LocationEdit/LocationEdit.js
+++ b/components/LocationEdit/LocationEdit.js
@@ -71,7 +71,7 @@ class LocationEdit extends Component {
 
    newService = () => {
     const { location } = this.props
-    const newServices = location.services || []
+    const newServices = location.services || {}
     const newService = blankService(location)
 
     newServices[newService.id] = newService


### PR DESCRIPTION
Firebase and our `decamelize` function requires a Location's Services to be an object and not an array.  We were losing new Services as a result.

@zendesk/volunteer 