### PR TITLE
Bind changesExist to submit result

### DIFF
--- a/components/OrganizationEdit/OrganizationEdit.js
+++ b/components/OrganizationEdit/OrganizationEdit.js
@@ -240,17 +240,21 @@ class OrganizationEdit extends Component {
     })
 
     updateOrganization(organization).then(response => {
+      let success = !response.hasOwnProperty('error')
       this.setState({
         hasSubmit: true,
-        submitResult: !response.hasOwnProperty('error')
+        submitResult: success,
+        changesExist: !success
       })
     })
 
     locations.map(location => {
       updateLocation(location).then(response => {
+        let success = !response.hasOwnProperty('error')
         this.setState({
           hasSubmit: true,
-          submitResult: !response.hasOwnProperty('error')
+          submitResult: success,
+          changesExist: !success
         })
       })
     })


### PR DESCRIPTION
We were never setting `changesExist` after we submitted the edit form.  This binds changes to the success of the update request.  The result should be that we will keep the unsaved changes state if a request fails for some reason.

@zendesk/volunteer 