### PR TITLE
ban null in FB normalization

### DIFF
--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -72,7 +72,7 @@ function ensureDefaultsForOrganization(organization) {
   return R.merge(ORGANIZATION_SCHEMA, camelize(organization))
 }
 
-function ensureDefaultsForOrganizations(organizations) {
+function ensureDefaultsForOrganizations(organizations = []) {
   return Object.keys(organizations).map(orgId => {
     return ensureDefaultsForOrganization(organizations[orgId])
   })
@@ -94,7 +94,7 @@ function ensureDefaultsForLocation(location) {
   return R.merge(defaultLocation, { services: defaultServices })
 }
 
-function ensureDefaultsForLocations(locations) {
+function ensureDefaultsForLocations(locations = []) {
   return Object.keys(locations).map(locationId => (
     ensureDefaultsForLocation(locations[locationId])
   ))
@@ -184,7 +184,7 @@ export function fetchOrganizations() {
 
   return fetch(url)
     .then(response => response.json())
-    .then(organizations => ensureDefaultsForOrganizations(organizations))
+    .then((organizations) => ensureDefaultsForOrganizations(organizations))
 }
 
 export function fetchOrganization(id) {

--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -72,8 +72,8 @@ function ensureDefaultsForOrganization(organization) {
   return R.merge(ORGANIZATION_SCHEMA, camelize(organization))
 }
 
-function ensureDefaultsForOrganizations(organizations = []) {
-  return Object.keys(organizations).map(orgId => {
+function ensureDefaultsForOrganizations(organizations) {
+  return Object.keys(organizations || []).map(orgId => {
     return ensureDefaultsForOrganization(organizations[orgId])
   })
 }
@@ -94,8 +94,8 @@ function ensureDefaultsForLocation(location) {
   return R.merge(defaultLocation, { services: defaultServices })
 }
 
-function ensureDefaultsForLocations(locations = []) {
-  return Object.keys(locations).map(locationId => (
+function ensureDefaultsForLocations(locations) {
+  return Object.keys(locations || []).map(locationId => (
     ensureDefaultsForLocation(locations[locationId])
   ))
 }

--- a/core/firebaseRestAPI.js
+++ b/core/firebaseRestAPI.js
@@ -184,7 +184,7 @@ export function fetchOrganizations() {
 
   return fetch(url)
     .then(response => response.json())
-    .then((organizations) => ensureDefaultsForOrganizations(organizations))
+    .then(organizations => ensureDefaultsForOrganizations(organizations))
 }
 
 export function fetchOrganization(id) {


### PR DESCRIPTION
Firebase collections return null if they are empty, even if they're meant to be empty as a default state.

This changes the "schema" of firebase to:

```graphql
{
  organizations: [Organization!]!
  locations: [Location!]!
}
```

from 

```graphql
{
  organizations: [Organization!]
  locations: [Location!]
}
```