### PR TITLE
Use Firebase API key for Google Maps

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -47,7 +47,8 @@ In the project root, you will find three configuration files:
     title: 'Link-SF',           // Your website title
     url: 'https://link-sf.com', // Your website URL
     project: 'link-sf',         // Firebase project. See README.md -> How to Deploy
-    trackingID: 'UA-XXXXX-Y',   // Google Analytics Site's ID
+    trackingID: '[GOOGLE_ANALYTICS_KEY]',   // Google Analytics Site's ID
+    firebaseApiKey: "[FIREBASE_API_KEY]",  // Firebase API Key
   };
   ```
 

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -6,7 +6,7 @@
     <title><%= config.title %></title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDDdHRnaDD-_z2aNUqyxxCoRBAf6PWZjS4&libraries=geometry,places"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<%= config.firebaseApiKey %>&libraries=geometry,places"></script>
     <link rel="apple-touch-icon" href="apple-touch-icon.png">
     <link rel="stylesheet" href="/main.css">
   </head>

--- a/run.js
+++ b/run.js
@@ -24,7 +24,8 @@ const config = {
   title: 'Link-SF',           // Your website title
   url: 'https://link-sf.com', // Your website URL
   project: 'link-sf',         // Firebase project. See README.md -> How to Deploy
-  trackingID: 'UA-46981709-1',   // Google Analytics Site's ID
+  trackingID: '[GOOGLE_ANALYTICS_KEY]',   // Google Analytics Site's ID
+  firebaseApiKey: "[FIREBASE_API_KEY]",  // Firebase API Key
 };
 
 const tasks = new Map(); // The collection of automation tasks ('clean', 'build', 'publish', etc.)


### PR DESCRIPTION
We were using a hard-coded Google Maps API key...

![](https://media1.giphy.com/media/wMvESGxZ0Cqd2/giphy.gif?cid=348844935d13df7b3036484c4503ba88&rid=giphy.gif)

This updates the API key to use the existing Firebase API key required for the app already.

@zendesk/volunteer 